### PR TITLE
fixing holoviews/geoviews link

### DIFF
--- a/_episodes/06-other-tools.md
+++ b/_episodes/06-other-tools.md
@@ -21,4 +21,4 @@ var divElement = document.getElementById('viz1536789373846');                   
 
 ### Holoviews + Geoviews + Datashader
 
-Dealing with a *huge* quantity of geospatial data, and want an interactive visualization? [Holoviews](http://holoviews.org/) is a very powerful data-aware Python visualization library, and has a geospatial component called [GeoViews](http://geoviews.org). They have a great set of tutorials, including one about creating fast, easy to use maps with [huge numbers of data points](http://pyviz.org/tutorial/10_Working_with_Large_Datasets.html). 
+Dealing with a *huge* quantity of geospatial data, and want an interactive visualization? [Holoviews](http://holoviews.org/) is a very powerful data-aware Python visualization library, and has a geospatial component called [GeoViews](http://geoviews.org). They have a great set of tutorials, including one about creating fast, easy to use maps with [huge numbers of data points](https://holoviz.org/tutorial/Large_Data.html). 


### PR DESCRIPTION
pyviz tools (holoviews, geoviews, hvplot, panel) are now called holoviz tools, and what used to be on pyviz.org is now on holoviz.org